### PR TITLE
Set foreground color when background color is set.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.0b4 (unreleased)
+------------------
+
+- If we set background to 'white' we should set foreground to 'black' to avoid
+  people getting white font on white background if they use white font color
+  for their plone sites.  [saily]
+
+
 1.0b3 (2013-02-04)
 ------------------
 

--- a/plone/formwidget/querystring/querywidget.css
+++ b/plone/formwidget/querystring/querywidget.css
@@ -69,11 +69,12 @@ dl.multipleSelectionWidget,
 }
 .multipleSelectionWidget dd {
     width: 198px;
-    background: white;
+    background: #FFF;
     overflow:auto;
 }
 .multipleSelectionWidget label {
     display: block;
+    color: #000;
 }
 .querywidget {
     float: left;

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0b3'
+version = '1.0b4'
 
 long_description = open("README.rst").read() + "\n" + \
     open("CHANGES.rst").read()


### PR DESCRIPTION
If we set background to 'white' we should set foreground to 'black' to avoid people getting white font on white background if they use white font color for their plone sites.
