### PR TITLE
Fix criteria checkbox rendering if value contains non ASCII characters.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix criteria checkbox rendering if value contains non ASCII characters.
+  [rnixx]
 
 
 1.1.3 (2014-11-01)
@@ -13,6 +14,7 @@ Changelog
 - Fixed sort index selection which was not preserved when editing collection
   criteria.
   [naro]
+
 - make compatible with jQuery >= 1.9
   [petschki]
 

--- a/plone/formwidget/querystring/input.pt
+++ b/plone/formwidget/querystring/input.pt
@@ -44,7 +44,7 @@
                         <tal:values repeat="index python:indexes[row.i]['values'].keys()">
                             <label>
                                 <input type="checkbox" name="form.widgets.query.v:records:list"
-                                       tal:attributes="name python:str(fieldName)+'.v:records:list'; value index;
+                                       tal:attributes="name python:str(fieldName)+'.v:records:list'; value python:index.decode('utf-8');
                                        checked python: row.has_key('v') and index in row.v and 'checked' or nothing"/>
                                 <span tal:content="python:indexes[row.i]['values'][index]['title']"/>
                             </label>
@@ -123,7 +123,7 @@
                 <dd>
                     <tal:values repeat="index python:indexes[request.form['addindex']]['values'].keys()">
                         <label>
-                            <input type="checkbox" name="form.widgets.query.v:records:list" tal:attributes="name python:str(fieldName)+'.v:records:list'; value index" />
+                            <input type="checkbox" name="form.widgets.query.v:records:list" tal:attributes="name python:str(fieldName)+'.v:records:list'; value python:index.decode('utf-8')" />
                             <span tal:content="python:indexes[request.form['addindex']]['values'][index]['title']"/>
                         </label>
                     </tal:values>


### PR DESCRIPTION
fixes #9 

not sure whether it would be better to fix IQuerystringRegistryReader implementation in plone.app.querystring to decode index value's keys properly, but that might effect some lower level stuff, so i just decoded in template. BTW - the traceback was really crappy. The wrapping template swallowed the inner template traceback, so no senceful hint was displayed what happend at all.

cheers
