### PR TITLE
Fix way to decode utf8 into template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,10 @@ Changelog
 1.1.6 (unreleased)
 ------------------
 
-New:
-
-- *add item here*
-
 Fixes:
 
-- *add item here*
+- Fix way to decode utf-8 into template.
+  [bsuttor]
 
 
 1.1.5 (2015-07-18)

--- a/plone/formwidget/querystring/input.pt
+++ b/plone/formwidget/querystring/input.pt
@@ -44,7 +44,7 @@
                         <tal:values repeat="index python:indexes[row.i]['values'].keys()">
                             <label>
                                 <input type="checkbox" name="form.widgets.query.v:records:list"
-                                       tal:attributes="name python:str(fieldName)+'.v:records:list'; value python:index.decode('utf-8');
+                                       tal:attributes="name python:str(fieldName)+'.v:records:list'; value python:view.decode(index);
                                        checked python: row.has_key('v') and index in row.v and 'checked' or nothing"/>
                                 <span tal:content="python:indexes[row.i]['values'][index]['title']"/>
                             </label>
@@ -80,7 +80,7 @@
 			    tal:attributes="name python:str(fieldName)+'.v:records'; value python:row['v']"/>
 		     <span i18n:translate="">days</span>
 		</div>
-		
+
                 <input class="querywidget queryvalue relativePathWidget"
                        autocomplete="off" type="text" name="form.widgets.query.v:records"
                        tal:attributes="name python:str(fieldName)+'.v:records'; value python:row['v']"
@@ -123,7 +123,7 @@
                 <dd>
                     <tal:values repeat="index python:indexes[request.form['addindex']]['values'].keys()">
                         <label>
-                            <input type="checkbox" name="form.widgets.query.v:records:list" tal:attributes="name python:str(fieldName)+'.v:records:list'; value python:index.decode('utf-8')" />
+                            <input type="checkbox" name="form.widgets.query.v:records:list" tal:attributes="name python:str(fieldName)+'.v:records:list'; value python:view.decode(index)" />
                             <span tal:content="python:indexes[request.form['addindex']]['values'][index]['title']"/>
                         </label>
                     </tal:values>
@@ -141,7 +141,7 @@
             <div class="querywidget queryvalue dateWidget"
                  tal:condition="python:indexes[request.form['addindex']]['operators'][request.form['addoperator']]['widget'] == 'DateWidget'">
                 <input autocomplete="off" type="text" class="queryvalue" tal:attributes="name python:str(fieldName)+'.v:records';" name="form.widgets.query.v:records" />
-		
+
             </div>
 
             <div class="querywidget queryvalue dateRangeWidget"

--- a/plone/formwidget/querystring/widget.py
+++ b/plone/formwidget/querystring/widget.py
@@ -11,6 +11,7 @@ from plone.app.querystring.querybuilder import QueryBuilder
 from plone.app.querystring.interfaces import IQuerystringRegistryReader
 from plone.formwidget.querystring.interfaces import IQueryStringWidget
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.utils import safe_unicode
 
 
 class QueryStringWidget(Widget):
@@ -54,7 +55,6 @@ class QueryStringWidget(Widget):
         return getMultiAdapter((listing, self.request),
             name='display_query_results')(**options)
 
-
     def js(self):
         language = getattr(self.request, 'LANGUAGE', 'en')
         calendar = self.request.locale.dates.calendars[self.calendar_type]
@@ -80,6 +80,9 @@ class QueryStringWidget(Widget):
                     }
                 });
             </script>''' % dict(defaultlang=defaultlang, localize=localize)
+
+    def decode(self, value):
+        return safe_unicode(value)
 
 
 @implementer(z3c.form.interfaces.IFieldWidget)


### PR DESCRIPTION
Because I had some error : 

UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 22: ordinal not in range(128)

And it's always better to use "safe_unicode" than .decode('utf8')