### PR TITLE
fix calculation of the baseUrl in queryresults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Recent Plone 4.3 versions have a change in the base href calculation. Fix
+  calculation of the baseUrl in updating the queryresults in the widgets if
+  /edit is part of the base href.
+  [fredvd, maurits]
 
 1.1.9 (2017-05-06)
 ------------------

--- a/plone/formwidget/querystring/querywidget.js
+++ b/plone/formwidget/querystring/querywidget.js
@@ -201,12 +201,19 @@
 
     $.querywidget.updateSearch = function () {
         var context_url = (function() {
-            var baseUrl, pieces;
+            var baseUrl, pieces, index;
             baseUrl = $('base').attr('href');
             if (!baseUrl) {
                 pieces = window.location.href.split('/');
                 pieces.pop();
                 baseUrl = pieces.join('/');
+            }
+            index = baseUrl.lastIndexOf('/');
+            if (index > -1 && baseUrl.lastIndexOf('edit') > index) {
+                // The url is for an edit page, so we strip the last part,
+                // otherwise we wrongly get /edit/@@querybuilder_html_results
+                // 'edit' can be 'atct_edit' too.
+                baseUrl = baseUrl.slice(0, index);
             }
             return baseUrl;
         })();


### PR DESCRIPTION
Recent Plone 4.3 versions have a change in the base href calculation. Fix calculation of the baseUrl in updating the queryresults in the widgets if /edit is part of the base href.