### PR TITLE
Fix deprecated import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- fixed deprecated import ``zope.site.hooks.getSite``
+  [petschki]
 
 
 1.1.10 (2017-08-09)

--- a/plone/formwidget/querystring/widget.py
+++ b/plone/formwidget/querystring/widget.py
@@ -1,17 +1,19 @@
-from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
-from zope.component import getUtility
-from zope.component import getMultiAdapter
-from zope.interface import implementer, implementer
-from zope.site.hooks import getSite
+# -*- coding: utf-8 -*-
 import z3c.form.interfaces
 import z3c.form.util
-from z3c.form.widget import FieldWidget
-from z3c.form.widget import Widget
-from plone.app.querystring.querybuilder import QueryBuilder
+
+from Products.CMFPlone.utils import safe_unicode
 from plone.app.querystring.interfaces import IQuerystringRegistryReader
+from plone.app.querystring.querybuilder import QueryBuilder
 from plone.formwidget.querystring.interfaces import IQueryStringWidget
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.utils import safe_unicode
+from z3c.form.widget import FieldWidget
+from z3c.form.widget import Widget
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.component.hooks import getSite
+from zope.interface import implementer
 
 
 @implementer(IQueryStringWidget)


### PR DESCRIPTION
zope.site.hooks is deprecated since zope.site=3.7.1 (2009-11-18)

fixes #22 